### PR TITLE
Added: custom fields to add shopify order id and customer id on salesorder, cash sales and customer imports. (71-add-hc-shopify-order-id-and-customer-id-custom-fields)

### DIFF
--- a/src/Objects/CashSale/custbody_hc_shopify_pos_number.xml
+++ b/src/Objects/CashSale/custbody_hc_shopify_pos_number.xml
@@ -1,0 +1,14 @@
+<transactionbodycustomfield scriptid="custbody_hc_shopify_pos_number">
+  <accesslevel>2</accesslevel>
+  <bodydeposit>T</bodydeposit>
+  <bodyitemfulfillment>T</bodyitemfulfillment>
+  <bodyjournal>T</bodyjournal>
+  <bodysale>T</bodysale>
+  <displaytype>NORMAL</displaytype>
+  <fieldtype>TEXT</fieldtype>
+  <globalsearch>T</globalsearch>
+  <label>HC Shopify POS Order Id</label>
+  <searchlevel>2</searchlevel>
+  <storevalue>T</storevalue>
+  <subtab>TRANSACTIONMAIN</subtab>
+</transactionbodycustomfield>

--- a/src/Objects/CashSale/custimport_add_cashsale_hc.xml
+++ b/src/Objects/CashSale/custimport_add_cashsale_hc.xml
@@ -41,6 +41,14 @@
           </columnreference>
         </fieldmapping>
         <fieldmapping>
+          <field>[scriptid=custbody_hc_shopify_pos_number]</field>
+          <columnreference>
+            <column>HC Shopify POS Order Id</column>
+            <file>CASHSALE</file>
+            <type>NAME</type>
+          </columnreference>
+        </fieldmapping>
+        <fieldmapping>
           <field>DEPARTMENT</field>
           <columnreference>
             <column>Department</column>

--- a/src/Objects/Customer/custentity_hc_shop_cust_id.xml
+++ b/src/Objects/Customer/custentity_hc_shop_cust_id.xml
@@ -1,0 +1,14 @@
+<entitycustomfield scriptid="custentity_hc_shop_cust_id">
+  <accesslevel>2</accesslevel>
+  <appliestocustomer>T</appliestocustomer>
+  <displaytype>NORMAL</displaytype>
+  <encryptatrest>F</encryptatrest>
+  <fieldtype>TEXT</fieldtype>
+  <globalsearch>F</globalsearch>
+  <isformula>F</isformula>
+  <ismandatory>F</ismandatory>
+  <isparent>F</isparent>
+  <label>HC Shopify Customer Id</label>
+  <searchlevel>2</searchlevel>
+  <storevalue>T</storevalue>
+</entitycustomfield>

--- a/src/Objects/Customer/custimport_customer_hc.xml
+++ b/src/Objects/Customer/custimport_customer_hc.xml
@@ -42,6 +42,14 @@
           </columnreference>
         </fieldmapping>
         <fieldmapping>
+          <field>[scriptid=custentity_hc_shop_cust_id]</field>
+          <columnreference>
+            <column>HC Shopify Customer Id</column>
+            <file>CUSTOMER</file>
+            <type>NAME</type>
+          </columnreference>
+        </fieldmapping>
+        <fieldmapping>
           <field>ENTITYSTATUS</field>
           <columnreference>
             <column>Status</column>

--- a/src/Objects/SalesOrder/custbody_hc_shopify_so_number.xml
+++ b/src/Objects/SalesOrder/custbody_hc_shopify_so_number.xml
@@ -1,0 +1,18 @@
+<transactionbodycustomfield scriptid="custbody_hc_shopify_so_number">
+  <accesslevel>2</accesslevel>
+  <bodydeposit>T</bodydeposit>
+  <bodyitemfulfillment>T</bodyitemfulfillment>
+  <bodyjournal>T</bodyjournal>
+  <bodysale>T</bodysale>
+  <displaytype>NORMAL</displaytype>
+  <encryptatrest>F</encryptatrest>
+  <fieldtype>TEXT</fieldtype>
+  <globalsearch>T</globalsearch>
+  <isformula>F</isformula>
+  <ismandatory>F</ismandatory>
+  <isparent>F</isparent>
+  <label>HC Shopify Sales Order Id</label>
+  <searchlevel>2</searchlevel>
+  <storevalue>T</storevalue>
+  <subtab>TRANSACTIONMAIN</subtab>
+</transactionbodycustomfield>

--- a/src/Objects/SalesOrder/custimport_add_salesorders_hc.xml
+++ b/src/Objects/SalesOrder/custimport_add_salesorders_hc.xml
@@ -41,6 +41,14 @@
           </columnreference>
         </fieldmapping>
         <fieldmapping>
+          <field>[scriptid=custbody_hc_shopify_so_number]</field>
+          <columnreference>
+            <column>HC Shopify Sales Order Id</column>
+            <file>SALESORDER</file>
+            <type>NAME</type>
+          </columnreference>
+        </fieldmapping>
+        <fieldmapping>
           <field>DEPARTMENT</field>
           <columnreference>
             <column>Department</column>

--- a/src/deploy.xml
+++ b/src/deploy.xml
@@ -46,6 +46,9 @@
         <path>~/Objects/SalesOrder/custbody_hc_sales_channel.xml</path>
         <path>~/Objects/SalesOrder/custcol_hc_item_tag.xml</path>
         <path>~/Objects/SalesOrder/custcol_hc_order_line_id.xml</path>
+        <path>~/Objects/SalesOrder/custbody_hc_shopify_so_number.xml</path>
+        <path>~/Objects/CashSale/custbody_hc_shopify_pos_number.xml</path>
+        <path>~/Objects/Customer/custentity_hc_shop_cust_id.xml</path>
 
         <!--Custom Form-->
         <path>~/Objects/SalesOrder/custform_hc_sales_order_form.xml</path>


### PR DESCRIPTION
… 