### PR TITLE
Improved: Included handling of HC Shipment Item Seq ID for Store TO Fulfillment

### DIFF
--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedStoreTOFulfillmentJson_v2.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedStoreTOFulfillmentJson_v2.js
@@ -68,8 +68,7 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp', 'N/task', 'N/error'],
                     'externalId': fulfillmentInternalId,
                     'shipmentId': contextValues.values.custbody_hc_shipment_id,
                     'lineId': orderline,
-                    'productSku': contextValues.values.item.value,
-                    'productIdType': "NETSUITE_PRODUCT_ID"
+                    'shipmentItemSeqId': contextValues.values.custcol_hc_shipment_item_seq_id
                 };
             }
 
@@ -97,8 +96,7 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp', 'N/task', 'N/error'],
 
                 itemFulfillmentMap.items.push({
                     externalId: item.lineId,
-                    productIdType: item.productIdType,
-                    productIdValue: item.productSku
+                    shipmentItemSeqId: item.shipmentItemSeqId
                 });
             });
 

--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_SC_ImportTOItemFulfillment_v2.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_SC_ImportTOItemFulfillment_v2.js
@@ -147,6 +147,7 @@ define(['N/search', 'N/record', 'N/error', 'N/sftp', 'N/file', 'N/runtime'], fun
                                     for (var itemIndex = 0; itemIndex < itemList.length; itemIndex++) {
                                         var lineId = Number(itemList[itemIndex].lineId) + 1;
                                         lineId = lineId.toString();
+                                        var shipmentItemSeqId = itemList[itemIndex].shipmentItemSeqId;
                                         var quantity = itemList[itemIndex].quantity;
                                         var tags = itemList[itemIndex].tags; 
 
@@ -164,6 +165,13 @@ define(['N/search', 'N/record', 'N/error', 'N/sftp', 'N/file', 'N/runtime'], fun
                                                     fieldId: 'quantity',
                                                     line: j,
                                                     value: quantity
+                                                });
+
+                                                itemFulfillmentRecord.setSublistValue({
+                                                    sublistId: 'item',
+                                                    fieldId: 'custcol_hc_shipment_item_seq_id',
+                                                    line: j,
+                                                    value: shipmentItemSeqId
                                                 });
 
                                                 itemFulfillmentRecord.setSublistValue({


### PR DESCRIPTION
1. Save HC Shipment Item Seq ID, the new custom column, on Item Fulfillment Line item.
2. Export HC Shipment Item Seq ID from NS, now NS Product ID is not needed. This will be used to update the Shipment Item in HC, else only using productId results in incorrect update when TO with same product in multiple line items

Closes #246 