### PR TITLE
Fixed: WH TO Fulfillment itemExternalId value preparation

### DIFF
--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedWHTOFulfillmentJson_v2.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedWHTOFulfillmentJson_v2.js
@@ -104,8 +104,8 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp', 'N/task', 'N/error'],
 
             // Build list of items for the first package
             const items = values.map((line) => ({
-                externalId: line.lineId,         
-                itemExternalId: line.lineId,    
+                externalId: line.lineId,   
+                itemExternalId: (parseInt(line.lineId) - 1).toString(),
                 productIdType: line.productIdType,
                 productIdValue: line.productSku,  
                 quantity: line.quantity          


### PR DESCRIPTION
1. it should be lineId - 1 
2. We have done the change here to use the itemExternalId in map#WhTransferOrderFulfillment service in netsuite-connector to get the OrderItem Seq Id.