### PR TITLE
Replace Inventory Adjustment Field hcOrderId with orderName #305

### DIFF
--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_CreateTOReceiptAndAdjustment.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_CreateTOReceiptAndAdjustment.js
@@ -89,8 +89,8 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp'],
             unreconciledTransferOrder = JSON.parse(contents);
 
             connection.move({
-                from: '/reconciliation/' + fileName,
-                to: '/reconciliation/archive/' + fileName
+              from: '/reconciliation/' + fileName,
+              to: '/reconciliation/archive/' + fileName
             })
             log.debug('File moved!');
             break;
@@ -256,7 +256,7 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp'],
           });
 
           transferOrderAdjustmentRecord.setValue({
-            fieldId: 'custbody_hc_inventory_adj_number',
+            fieldId: 'custbody_hc_order_id',
             value: hcOrderId
           });
 

--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_CreateTOReceiptAndAdjustment.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_CreateTOReceiptAndAdjustment.js
@@ -256,8 +256,8 @@ define(['N/file', 'N/record', 'N/search', 'N/sftp'],
           });
 
           transferOrderAdjustmentRecord.setValue({
-            fieldId: 'custbody_hc_order_id',
-            value: hcOrderId
+            fieldId: 'custbody_hc_inventory_adj_number',
+            value: orderName
           });
 
           // 1) OVER RECEIVED = Increase Qty (Positive Adjustment)


### PR DESCRIPTION
Summary:
Replaced the custom body field `custbody_hc_inventory_adj_number` with `custbody_hc_order_id` in `HC_MR_CreateTOReceiptAndAdjustment.js` to align with new naming conventions and standardization.

Closes #305