### PR TITLE
Fix: Reset 'HC Closed' flag on Transfer Order copy (#310)

### DIFF
--- a/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_CS_TO_Copy_Reset_Custom_Fields_v2.js
+++ b/src/FileCabinet/SuiteScripts/TransferOrderV2/HC_CS_TO_Copy_Reset_Custom_Fields_v2.js
@@ -22,6 +22,26 @@ define([], () => {
             fieldId: 'custbody_hc_order_id',
             value: ''
          });
+
+         var lineCount = currentRecord.getLineCount({ sublistId: 'item' });
+
+         for (var i = 0; i < lineCount; i++) {
+
+            currentRecord.selectLine({
+               sublistId: 'item',
+               line: i
+            });
+
+            currentRecord.setCurrentSublistValue({
+               sublistId: 'item',
+               fieldId: 'custcol_hc_closed',
+               value: false
+            });
+
+            currentRecord.commitLine({
+               sublistId: 'item'
+            });
+         }
       }
    }
 


### PR DESCRIPTION
### Description
This PR addresses issue #310.

When creating a new Transfer Order by copying an existing one, the custom field `custcol_hc_closed` on the line items was retaining its value (potentially true), causing the new order lines to be marked as closed incorrectly.

This change explicitly resets the `custcol_hc_closed` flag to `false` for all line items when a Transfer Order is copied.

### Changes
- Updated `HC_CS_TO_Copy_Reset_Custom_Fields_v2.js` to iterate through line items in `copy` mode and set `custcol_hc_closed` to `false`.

### Related Issue
- #310