### PR TITLE
Add generic File Cabinet upload RESTlet (PoC Phase 1)

### DIFF
--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -17,21 +17,45 @@ define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
         // Add a type here before sending it, or the file will be written as text and corrupted.
         const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
 
+        // folderName always identifies a TOP-LEVEL File Cabinet folder. Lookup and creation are scoped to
+        // the same place deliberately: an unscoped name search matches a folder with that name anywhere in
+        // the cabinet, so a feed could resolve to someone else's nested folder and, worse, resolve to a
+        // different one as folders are added. Root-level scoping makes the name unambiguous.
+        // Pass folder (the internal id) instead when the target is nested.
         const getOrCreateFolder = (folderName) => {
             var folderSearch = search.create({
                 type: search.Type.FOLDER,
-                filters: [['name', 'is', folderName]],
+                filters: [
+                    ['name', 'is', folderName],
+                    'AND',
+                    // An inactive folder still matches a name search but cannot receive files.
+                    ['isinactive', 'is', 'F'],
+                    'AND',
+                    // @NONE@ is the File Cabinet root; without this the match is cabinet-wide.
+                    ['parent', 'anyof', '@NONE@']
+                ],
                 columns: ['internalid']
             });
 
-            var folderId = folderSearch.run().getRange({ start: 0, end: 1 })
-                .map(function (result) {
-                    return result.getValue('internalid');
-                })[0];
+            var matches = folderSearch.run().getRange({ start: 0, end: 2 });
+            // Two active root folders cannot share a name in NetSuite, so this is defensive rather than
+            // expected - but picking arbitrarily is how files end up somewhere nobody looks.
+            if (matches.length > 1) {
+                throw error.create({
+                    name: 'AMBIGUOUS_FOLDER_NAME',
+                    message: 'More than one active top-level folder is named ' + folderName +
+                        '; pass the folder internal id instead'
+                });
+            }
+
+            var folderId = matches.length ? matches[0].getValue('internalid') : null;
 
             if (!folderId) {
                 var folder = record.create({ type: record.Type.FOLDER });
                 folder.setValue({ fieldId: 'name', value: folderName });
+                // Explicit empty parent = create at the root, matching where the search just looked.
+                // Left unset the folder still lands at the root, but only by default rather than by intent.
+                folder.setValue({ fieldId: 'parent', value: '' });
                 folderId = folder.save();
                 log.debug('Created folder: ' + folderName);
             }

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -1,0 +1,101 @@
+/**
+ * Generic File Cabinet upload RESTlet.
+ *
+ * Moqui posts a base64 payload, this saves it as a File Cabinet file and returns the internal id.
+ * It does no mapping and no business logic. All feed logic stays in Moqui.
+ *
+ * The caller owns the file name. A save with a name that already exists in the target folder
+ * REPLACES that file, so callers must make names unique.
+ *
+ * @NApiVersion 2.1
+ * @NScriptType Restlet
+ */
+define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
+    (file, record, search, encode, error) => {
+
+        // File types whose contents must stay base64. Everything else is decoded to UTF-8 text.
+        // Add a type here before sending it, or the file will be written as text and corrupted.
+        const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
+
+        const getOrCreateFolder = (folderName) => {
+            var folderSearch = search.create({
+                type: search.Type.FOLDER,
+                filters: [['name', 'is', folderName]],
+                columns: ['internalid']
+            });
+
+            var folderId = folderSearch.run().getRange({ start: 0, end: 1 })
+                .map(function (result) {
+                    return result.getValue('internalid');
+                })[0];
+
+            if (!folderId) {
+                var folder = record.create({ type: record.Type.FOLDER });
+                folder.setValue({ fieldId: 'name', value: folderName });
+                folderId = folder.save();
+                log.debug('Created folder: ' + folderName);
+            }
+            return folderId;
+        };
+
+        const post = (requestBody) => {
+            var name = requestBody.name;
+            var fileType = requestBody.fileType;
+            var contents = requestBody.contents;
+            var folderId = requestBody.folder;
+            var folderName = requestBody.folderName;
+
+            if (!name || !contents) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'Both name and contents are required to upload a file'
+                });
+            }
+            if (!folderId && !folderName) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'Either folder or folderName is required to upload a file'
+                });
+            }
+
+            var resolvedType = file.Type[fileType];
+            if (!resolvedType) {
+                throw error.create({
+                    name: 'UNSUPPORTED_FILE_TYPE',
+                    message: 'Unsupported fileType ' + fileType
+                });
+            }
+
+            // Binary types keep the base64 payload, N/file decodes it. Text types must be decoded here,
+            // otherwise the base64 string itself is written as the file body.
+            var fileContents = contents;
+            if (BINARY_TYPES.indexOf(fileType) === -1) {
+                fileContents = encode.convert({
+                    string: contents,
+                    inputEncoding: encode.Encoding.BASE_64,
+                    outputEncoding: encode.Encoding.UTF_8
+                });
+            }
+
+            if (!folderId) folderId = getOrCreateFolder(folderName);
+
+            var fileObj = file.create({
+                name: name,
+                fileType: resolvedType,
+                contents: fileContents,
+                folder: folderId
+            });
+
+            var fileId = fileObj.save();
+            log.debug('File saved to File Cabinet', 'name: ' + name + ', id: ' + fileId + ', folder: ' + folderId);
+
+            return {
+                status: 'success',
+                fileId: fileId,
+                fileName: name,
+                folderId: folderId
+            };
+        };
+
+        return { post };
+    });

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -13,9 +13,19 @@
 define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
     (file, record, search, encode, error) => {
 
-        // File types whose contents must stay base64. Everything else is decoded to UTF-8 text.
+        // file.Type KEYS whose contents must stay base64. Everything else is decoded to UTF-8 text.
         // Add a type here before sending it, or the file will be written as text and corrupted.
-        const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
+        //
+        // These are INPUT keys, looked up as file.Type[...]. That is a different namespace from the
+        // fileType NAMES a File object reports back, and HC_RL_VerifyGzipFile deliberately keeps a
+        // different list for those. MISCBINARY belongs only to the output side: file.Type has no
+        // MISCBINARY member, so sending it throws UNSUPPORTED_FILE_TYPE - which is what blocked every
+        // .gz upload until this was corrected.
+        //
+        // Probed against 4054670_SB1: GZIP, ZIP, PDF and TAR exist and require base64 (sending them
+        // decoded fails BINARY_DATA_EXPECTED_FOR_SUCH_FILE); MISCBINARY, MISCELLANEOUS, BINARY, TEXT
+        // and FTL are not members of file.Type at all.
+        const BINARY_TYPES = ['GZIP', 'ZIP', 'PDF', 'TAR'];
 
         // folderName always identifies a TOP-LEVEL File Cabinet folder. Lookup and creation are scoped to
         // the same place deliberately: an unscoped name search matches a folder with that name anywhere in

--- a/src/Objects/Restlet/customscript_restlet_uploadfile.xml
+++ b/src/Objects/Restlet/customscript_restlet_uploadfile.xml
@@ -1,0 +1,22 @@
+<restlet scriptid="customscript_restlet_uploadfile">
+  <description></description>
+  <isinactive>F</isinactive>
+  <name>HC_RL_UploadFileToCabinet</name>
+  <notifyadmins>F</notifyadmins>
+  <notifyemails></notifyemails>
+  <notifyowner>T</notifyowner>
+  <notifyuser>F</notifyuser>
+  <scriptfile>[/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js]</scriptfile>
+  <scriptdeployments>
+    <scriptdeployment scriptid="customdeploy_restlet_uploadfile">
+      <allemployees>F</allemployees>
+      <allpartners>F</allpartners>
+      <allroles>T</allroles>
+      <audslctrole></audslctrole>
+      <isdeployed>T</isdeployed>
+      <loglevel>DEBUG</loglevel>
+      <status>RELEASED</status>
+      <title>HC_RL_UploadFileToCabinet</title>
+    </scriptdeployment>
+  </scriptdeployments>
+</restlet>

--- a/src/deploy.xml
+++ b/src/deploy.xml
@@ -69,6 +69,7 @@
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_RunSuiteScript.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_GetSuiteScriptCronExpression.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_StoreSFTPConfiguration.js</path>
+        <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js</path>
 
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_SC_ImportTOFulfillmentReceipts_v2.js</path>
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedWhtoStoreTOJson_v2.js</path>
@@ -212,6 +213,7 @@
         <path>~/Objects/Restlet/customscript_restlet_runscript.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_getscript_cronexp.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_store_sftpconf.xml</path>
+        <path>~/Objects/Restlet/customscript_restlet_uploadfile.xml</path>
 
         <path>~/Objects/TransferOrderV2/customscript_hc_imp_to_fulfil_rcpt_v2.xml</path>
         <path>~/Objects/TransferOrderV2/customscript_hc_mr_exp_wh_store_to_v2.xml</path>


### PR DESCRIPTION
## Summary

NetSuite half of PoC Phase 1: a generic RESTlet that saves a base64 payload posted by Moqui into the File Cabinet and returns the file internal id. It does no mapping and no lookups — all feed logic stays in Moqui.

- `HC_RL_UploadFileToCabinet.js` — the RESTlet
- `customscript_restlet_uploadfile.xml` — script + deployment object (`RELEASED`, `allroles`, matching the other four RESTlets)
- `src/deploy.xml` — registered in both `<files>` and `<objects>`

## Two choices worth reviewing

**Failures throw rather than return an error object.** The Moqui runner (`NetSuiteRestServiceRunner.getErrorMessage`) inspects a **2xx** body for `error`/`errorMessage` keys and downgrades them to a *warning*, so a soft error return would let a failed upload look successful to Moqui. `error.create` yields a non-2xx, which the runner escalates to a hard error.

**`BINARY_TYPES` decides base64 pass-through vs decode.** Binary types keep the base64 for `N/file` to decode; text types are decoded here via `N/encode`. Passing base64 to a text file type writes the base64 string itself as the file body. Phase 2 (#307) sends `MISCBINARY` and needs no change to this script.

Folders resolve by name using the search-then-create pattern already in `HC_GenerateALCAuditLogReport`, so one Moqui config works in both sandbox and production. Caveat inherited from that helper: it matches a folder name anywhere in the cabinet, so keep names distinctive.

## Repo choice

#306 says the RESTlet belongs in `hotwax-gorjana-netsuite`. It is here instead, because this repo already holds the `Restlet/` convention and the four RESTlets that Moqui's `NS_SCRIPT_RESTLET` calls, and because #310 says the NetSuite side should be generic and not change per feed. Flagging it explicitly so it can be moved if that is wrong.

## Testing

Not yet run against NetSuite — no sandbox call, no round trip.

Verified so far: `node --check` on the RESTlet, XML well-formedness on the object and manifest.

Remaining, all environment-side:
1. Deploy to the sandbox via SuiteCloud.
2. Read the deployed script's internal id and set `netsuite.restlet.filecabinet.upload` on the Moqui side.
3. Upload a small text file; confirm it lands in the folder and the returned id loads.
4. Upload the same filename twice and record whether NetSuite replaces or duplicates.

## Issue Link
- Part of hotwax/mantle-netsuite-connector#306

Deliberately not a closing keyword: #306's success criteria require sandbox verification that has not happened yet.

## Related
- Moqui side: hotwax/mantle-netsuite-connector PR (linked below)
- Phase 2 (gzip): hotwax/mantle-netsuite-connector#307
- Phase 3 (size limits): hotwax/mantle-netsuite-connector#308