### PR TITLE
File Cabinet transport + gzip round trip — NetSuite side of epic #310 (Phases 1 and 2)

### DIFF
--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -17,21 +17,45 @@ define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
         // Add a type here before sending it, or the file will be written as text and corrupted.
         const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
 
+        // folderName always identifies a TOP-LEVEL File Cabinet folder. Lookup and creation are scoped to
+        // the same place deliberately: an unscoped name search matches a folder with that name anywhere in
+        // the cabinet, so a feed could resolve to someone else's nested folder and, worse, resolve to a
+        // different one as folders are added. Root-level scoping makes the name unambiguous.
+        // Pass folder (the internal id) instead when the target is nested.
         const getOrCreateFolder = (folderName) => {
             var folderSearch = search.create({
                 type: search.Type.FOLDER,
-                filters: [['name', 'is', folderName]],
+                filters: [
+                    ['name', 'is', folderName],
+                    'AND',
+                    // An inactive folder still matches a name search but cannot receive files.
+                    ['isinactive', 'is', 'F'],
+                    'AND',
+                    // @NONE@ is the File Cabinet root; without this the match is cabinet-wide.
+                    ['parent', 'anyof', '@NONE@']
+                ],
                 columns: ['internalid']
             });
 
-            var folderId = folderSearch.run().getRange({ start: 0, end: 1 })
-                .map(function (result) {
-                    return result.getValue('internalid');
-                })[0];
+            var matches = folderSearch.run().getRange({ start: 0, end: 2 });
+            // Two active root folders cannot share a name in NetSuite, so this is defensive rather than
+            // expected - but picking arbitrarily is how files end up somewhere nobody looks.
+            if (matches.length > 1) {
+                throw error.create({
+                    name: 'AMBIGUOUS_FOLDER_NAME',
+                    message: 'More than one active top-level folder is named ' + folderName +
+                        '; pass the folder internal id instead'
+                });
+            }
+
+            var folderId = matches.length ? matches[0].getValue('internalid') : null;
 
             if (!folderId) {
                 var folder = record.create({ type: record.Type.FOLDER });
                 folder.setValue({ fieldId: 'name', value: folderName });
+                // Explicit empty parent = create at the root, matching where the search just looked.
+                // Left unset the folder still lands at the root, but only by default rather than by intent.
+                folder.setValue({ fieldId: 'parent', value: '' });
                 folderId = folder.save();
                 log.debug('Created folder: ' + folderName);
             }

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -1,0 +1,101 @@
+/**
+ * Generic File Cabinet upload RESTlet.
+ *
+ * Moqui posts a base64 payload, this saves it as a File Cabinet file and returns the internal id.
+ * It does no mapping and no business logic. All feed logic stays in Moqui.
+ *
+ * The caller owns the file name. A save with a name that already exists in the target folder
+ * REPLACES that file, so callers must make names unique.
+ *
+ * @NApiVersion 2.1
+ * @NScriptType Restlet
+ */
+define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
+    (file, record, search, encode, error) => {
+
+        // File types whose contents must stay base64. Everything else is decoded to UTF-8 text.
+        // Add a type here before sending it, or the file will be written as text and corrupted.
+        const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
+
+        const getOrCreateFolder = (folderName) => {
+            var folderSearch = search.create({
+                type: search.Type.FOLDER,
+                filters: [['name', 'is', folderName]],
+                columns: ['internalid']
+            });
+
+            var folderId = folderSearch.run().getRange({ start: 0, end: 1 })
+                .map(function (result) {
+                    return result.getValue('internalid');
+                })[0];
+
+            if (!folderId) {
+                var folder = record.create({ type: record.Type.FOLDER });
+                folder.setValue({ fieldId: 'name', value: folderName });
+                folderId = folder.save();
+                log.debug('Created folder: ' + folderName);
+            }
+            return folderId;
+        };
+
+        const post = (requestBody) => {
+            var name = requestBody.name;
+            var fileType = requestBody.fileType;
+            var contents = requestBody.contents;
+            var folderId = requestBody.folder;
+            var folderName = requestBody.folderName;
+
+            if (!name || !contents) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'Both name and contents are required to upload a file'
+                });
+            }
+            if (!folderId && !folderName) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'Either folder or folderName is required to upload a file'
+                });
+            }
+
+            var resolvedType = file.Type[fileType];
+            if (!resolvedType) {
+                throw error.create({
+                    name: 'UNSUPPORTED_FILE_TYPE',
+                    message: 'Unsupported fileType ' + fileType
+                });
+            }
+
+            // Binary types keep the base64 payload, N/file decodes it. Text types must be decoded here,
+            // otherwise the base64 string itself is written as the file body.
+            var fileContents = contents;
+            if (BINARY_TYPES.indexOf(fileType) === -1) {
+                fileContents = encode.convert({
+                    string: contents,
+                    inputEncoding: encode.Encoding.BASE_64,
+                    outputEncoding: encode.Encoding.UTF_8
+                });
+            }
+
+            if (!folderId) folderId = getOrCreateFolder(folderName);
+
+            var fileObj = file.create({
+                name: name,
+                fileType: resolvedType,
+                contents: fileContents,
+                folder: folderId
+            });
+
+            var fileId = fileObj.save();
+            log.debug('File saved to File Cabinet', 'name: ' + name + ', id: ' + fileId + ', folder: ' + folderId);
+
+            return {
+                status: 'success',
+                fileId: fileId,
+                fileName: name,
+                folderId: folderId
+            };
+        };
+
+        return { post };
+    });

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js
@@ -13,9 +13,19 @@
 define(['N/file', 'N/record', 'N/search', 'N/encode', 'N/error'],
     (file, record, search, encode, error) => {
 
-        // File types whose contents must stay base64. Everything else is decoded to UTF-8 text.
+        // file.Type KEYS whose contents must stay base64. Everything else is decoded to UTF-8 text.
         // Add a type here before sending it, or the file will be written as text and corrupted.
-        const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
+        //
+        // These are INPUT keys, looked up as file.Type[...]. That is a different namespace from the
+        // fileType NAMES a File object reports back, and HC_RL_VerifyGzipFile deliberately keeps a
+        // different list for those. MISCBINARY belongs only to the output side: file.Type has no
+        // MISCBINARY member, so sending it throws UNSUPPORTED_FILE_TYPE - which is what blocked every
+        // .gz upload until this was corrected.
+        //
+        // Probed against 4054670_SB1: GZIP, ZIP, PDF and TAR exist and require base64 (sending them
+        // decoded fails BINARY_DATA_EXPECTED_FOR_SUCH_FILE); MISCBINARY, MISCELLANEOUS, BINARY, TEXT
+        // and FTL are not members of file.Type at all.
+        const BINARY_TYPES = ['GZIP', 'ZIP', 'PDF', 'TAR'];
 
         // folderName always identifies a TOP-LEVEL File Cabinet folder. Lookup and creation are scoped to
         // the same place deliberately: an unscoped name search matches a folder with that name anywhere in

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js
@@ -1,0 +1,101 @@
+/**
+ * Gunzip a File Cabinet file and report what it contains.
+ *
+ * Phase 2 of the File Cabinet PoC (hotwax/mantle-netsuite-connector#307). Moqui uploads a gzipped
+ * NDJSON feed, then calls this to prove the content survived. It creates no records and does no
+ * mapping - that is the generic creator, #336.
+ *
+ * The SHA-256 is over the decompressed bytes so the caller can compare it with a digest of the
+ * pre-gzip source. A record count alone would pass even if every line were mangled.
+ *
+ * @NApiVersion 2.1
+ * @NScriptType Restlet
+ */
+define(['N/file', 'N/compress', 'N/crypto', 'N/encode', 'N/error'],
+    (file, compress, crypto, encode, error) => {
+
+        // Same list as HC_RL_UploadFileToCabinet. For these types getContents() returns base64
+        // rather than text, so both the hash and the line split have to account for it.
+        const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
+
+        const sha256 = (contents, inputEncoding) => {
+            var hashObj = crypto.createHash({ algorithm: crypto.HashAlg.SHA256 });
+            hashObj.update({ input: contents, inputEncoding: inputEncoding });
+            return hashObj.digest({ outputEncoding: encode.Encoding.HEX }).toLowerCase();
+        };
+
+        // NDJSON is one record per line and normally ends with a newline, so the trailing empty
+        // string must not count. A blank line is not a record either.
+        //
+        // Filtering explicitly rather than trusting split(): JavaScript keeps trailing empty strings
+        // where Java discards them, so a naive count here would disagree with the Moqui producer by
+        // one on every feed file that ends in a newline - a phantom "lost record" on the first run.
+        const countRecords = (text) => {
+            var lines = text.split(/\r?\n/);
+            var count = 0;
+            for (var i = 0; i < lines.length; i++) {
+                if (lines[i].trim()) count++;
+            }
+            return count;
+        };
+
+        const post = (requestBody) => {
+            var fileId = requestBody.fileId;
+            if (!fileId) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'fileId is required to verify a gzipped file'
+                });
+            }
+
+            var gzippedFile = file.load({ id: fileId });
+            var compressedBytes = gzippedFile.size;
+
+            // Throws if the file is not actually gzip. Let that surface rather than reporting a
+            // zero count - "the thing we uploaded was not gzip" is a real finding, not an edge case.
+            var gunzippedFile = compress.gunzip({ file: gzippedFile });
+            var observedFileType = gunzippedFile.fileType;
+            var contents = gunzippedFile.getContents();
+
+            // NetSuite infers the gunzipped file's type. When it lands on a binary type, getContents()
+            // hands back base64, and hashing that string directly would report a mismatch that looks
+            // exactly like corruption. Hash the base64 with a BASE_64 inputEncoding instead, so the
+            // digest covers the true decoded bytes and never passes through a character-encoding
+            // conversion - which is the one thing that must not sit in the middle of an integrity check.
+            var isBinary = BINARY_TYPES.indexOf(observedFileType) !== -1;
+            var digest = sha256(contents, isBinary ? encode.Encoding.BASE_64 : encode.Encoding.UTF_8);
+
+            var text = isBinary
+                ? encode.convert({
+                    string: contents,
+                    inputEncoding: encode.Encoding.BASE_64,
+                    outputEncoding: encode.Encoding.UTF_8
+                })
+                : contents;
+
+            var recordCount = countRecords(text);
+
+            // Logged at audit level because observedFileType is the open question this PoC exists to
+            // answer, and #308 and #336 both need the answer.
+            log.audit('Gzip verify', 'fileId: ' + fileId +
+                ', observedFileType: ' + observedFileType +
+                ', compressedBytes: ' + compressedBytes +
+                ', decompressedChars: ' + text.length +
+                ', recordCount: ' + recordCount +
+                ', sha256: ' + digest);
+
+            return {
+                status: 'success',
+                fileId: fileId,
+                recordCount: recordCount,
+                sha256: digest,
+                // Character count, not bytes - String.length counts UTF-16 code units. Diagnostic only;
+                // integrity is the sha256's job.
+                decompressedChars: text.length,
+                compressedBytes: compressedBytes,
+                observedFileType: observedFileType
+            };
+        };
+
+        return { post };
+    });

--- a/src/FileCabinet/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js
+++ b/src/FileCabinet/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js
@@ -8,14 +8,45 @@
  * The SHA-256 is over the decompressed bytes so the caller can compare it with a digest of the
  * pre-gzip source. A record count alone would pass even if every line were mangled.
  *
+ * Phase 3 (#308) added a `mode` parameter to measure where each read path stops working:
+ *   contents  getContents() - the whole file at once, capped at 10MB (default, Phase 2 behaviour)
+ *   stream    lines.iterator() - line at a time, 10MB applies per line, so no practical file cap
+ *   both      run each in turn against the same file and report them separately
+ *
+ * IMPORTANT for callers: the uploaded file's NAME decides the gunzipped file's type, and the type
+ * decides how much fits. gunzip strips '.gz' and NetSuite infers the type from what is left, and
+ * File.fileType is read-only afterwards, so the name is the only control. Verified live against
+ * 4054670_SB1 by uploading ONE payload under five names: '.txt.gz' yields PLAINTEXT, '.csv.gz' CSV,
+ * '.json.gz' JSON, and both '.ndjson.gz' and a bare '.gz' yield MISCBINARY.
+ *
+ * What the type does NOT change is capacity. Measured both ways on this account, getContents() fails
+ * at exactly the same size - 68,100 records read, 68,200 threw SSS_FILE_CONTENT_SIZE_EXCEEDED, for
+ * PLAINTEXT and MISCBINARY alike. So the 10MB ceiling is on the file's content bytes, not on the
+ * base64 string a binary type hands back. An earlier reading of this code assumed base64 inflation
+ * cost a quarter of the headroom; it does not.
+ *
+ * Nor does the type decide streaming: contrary to the documentation, which describes lines.iterator()
+ * as being for text and .csv files, a MISCBINARY gunzip temp file streamed correctly here with a
+ * matching digest. Prefer '.txt.gz' regardless - getContents() then returns text instead of base64, so
+ * consumers skip a decode step, and the feed stays inside documented behaviour rather than relying on
+ * an undocumented one Oracle is free to change. It buys clarity and supportability, not capacity.
+ *
  * @NApiVersion 2.1
  * @NScriptType Restlet
  */
-define(['N/file', 'N/compress', 'N/crypto', 'N/encode', 'N/error'],
-    (file, compress, crypto, encode, error) => {
+define(['N/file', 'N/compress', 'N/crypto', 'N/encode', 'N/error', 'N/runtime'],
+    (file, compress, crypto, encode, error, runtime) => {
 
-        // Same list as HC_RL_UploadFileToCabinet. For these types getContents() returns base64
-        // rather than text, so both the hash and the line split have to account for it.
+        // NOT the same list as HC_RL_UploadFileToCabinet, despite the shared name. These are fileType
+        // NAMES that a File object reports, not file.Type input keys - two namespaces that overlap
+        // enough to look identical and are not.
+        //
+        // MISCBINARY is the entry that matters and it must stay here. It is what NetSuite reports for
+        // a gunzipped file whose name carries no recognized text extension, confirmed live. The same
+        // value is invalid as an INPUT, which is why the upload side must never send it.
+        //
+        // For these types getContents() returns base64 rather than text, so both the hash and the
+        // line split have to account for it.
         const BINARY_TYPES = ['MISCBINARY', 'ZIP', 'PDF'];
 
         const sha256 = (contents, inputEncoding) => {
@@ -39,22 +70,12 @@ define(['N/file', 'N/compress', 'N/crypto', 'N/encode', 'N/error'],
             return count;
         };
 
-        const post = (requestBody) => {
-            var fileId = requestBody.fileId;
-            if (!fileId) {
-                throw error.create({
-                    name: 'MISSING_REQUIRED_PARAM',
-                    message: 'fileId is required to verify a gzipped file'
-                });
-            }
+        const remainingUsage = () => runtime.getCurrentScript().getRemainingUsage();
 
-            var gzippedFile = file.load({ id: fileId });
-            var compressedBytes = gzippedFile.size;
-
-            // Throws if the file is not actually gzip. Let that surface rather than reporting a
-            // zero count - "the thing we uploaded was not gzip" is a real finding, not an edge case.
-            var gunzippedFile = compress.gunzip({ file: gzippedFile });
-            var observedFileType = gunzippedFile.fileType;
+        // Whole-file read. Capped at 10MB of file content by getContents(), which throws
+        // SSS_FILE_CONTENT_SIZE_EXCEEDED beyond it. The cap is on the content, not on the returned
+        // string: a binary type returns base64 and still fails at the same file size, measured.
+        const readViaContents = (gunzippedFile, observedFileType) => {
             var contents = gunzippedFile.getContents();
 
             // NetSuite infers the gunzipped file's type. When it lands on a binary type, getContents()
@@ -73,28 +94,135 @@ define(['N/file', 'N/compress', 'N/crypto', 'N/encode', 'N/error'],
                 })
                 : contents;
 
-            var recordCount = countRecords(text);
-
-            // Logged at audit level because observedFileType is the open question this PoC exists to
-            // answer, and #308 and #336 both need the answer.
-            log.audit('Gzip verify', 'fileId: ' + fileId +
-                ', observedFileType: ' + observedFileType +
-                ', compressedBytes: ' + compressedBytes +
-                ', decompressedChars: ' + text.length +
-                ', recordCount: ' + recordCount +
-                ', sha256: ' + digest);
-
             return {
-                status: 'success',
-                fileId: fileId,
-                recordCount: recordCount,
+                recordCount: countRecords(text),
                 sha256: digest,
                 // Character count, not bytes - String.length counts UTF-16 code units. Diagnostic only;
                 // integrity is the sha256's job.
-                decompressedChars: text.length,
-                compressedBytes: compressedBytes,
-                observedFileType: observedFileType
+                decompressedChars: text.length
             };
+        };
+
+        // Line-at-a-time read. The 10MB limit applies per line rather than per file, so this is the only
+        // path with no practical ceiling on record count.
+        //
+        // The digest is built incrementally, one update() per line, so integrity is still checked end to
+        // end without ever holding the file in memory. Each line is rehydrated as value + '\n', which
+        // reproduces the source exactly for an NDJSON file that ends in a newline - so a digest matching
+        // the contents-mode one is also proof that the iterator yielded no phantom trailing line.
+        // linesYielded is reported separately precisely so that assumption stays falsifiable.
+        const readViaStream = (gunzippedFile) => {
+            var hashObj = crypto.createHash({ algorithm: crypto.HashAlg.SHA256 });
+            var linesYielded = 0;
+            var recordCount = 0;
+            var maxLineChars = 0;
+            var decompressedChars = 0;
+
+            gunzippedFile.lines.iterator().each((line) => {
+                var value = line.value;
+                linesYielded++;
+                decompressedChars += value.length + 1;
+                if (value.length > maxLineChars) maxLineChars = value.length;
+                if (value.trim()) recordCount++;
+                hashObj.update({ input: value + '\n', inputEncoding: encode.Encoding.UTF_8 });
+                return true;
+            });
+
+            return {
+                recordCount: recordCount,
+                sha256: hashObj.digest({ outputEncoding: encode.Encoding.HEX }).toLowerCase(),
+                decompressedChars: decompressedChars,
+                linesYielded: linesYielded,
+                maxLineChars: maxLineChars
+            };
+        };
+
+        const post = (requestBody) => {
+            var fileId = requestBody.fileId;
+            if (!fileId) {
+                throw error.create({
+                    name: 'MISSING_REQUIRED_PARAM',
+                    message: 'fileId is required to verify a gzipped file'
+                });
+            }
+
+            // Defaults to the whole-file read so the Phase 2 contract is unchanged for existing callers.
+            var mode = requestBody.mode || 'contents';
+            if (['contents', 'stream', 'both'].indexOf(mode) === -1) {
+                throw error.create({
+                    name: 'INVALID_MODE',
+                    message: 'mode must be one of contents, stream or both; got ' + mode
+                });
+            }
+
+            var gzippedFile = file.load({ id: fileId });
+            var compressedBytes = gzippedFile.size;
+
+            // Throws if the file is not actually gzip. Let that surface rather than reporting a
+            // zero count - "the thing we uploaded was not gzip" is a real finding, not an edge case.
+            var gunzippedFile = compress.gunzip({ file: gzippedFile });
+            var observedFileType = gunzippedFile.fileType;
+
+            var response = {
+                status: 'success',
+                fileId: fileId,
+                mode: mode,
+                compressedBytes: compressedBytes,
+                observedFileType: observedFileType,
+                usageAtStart: remainingUsage()
+            };
+
+            // Each read is captured rather than allowed to abort the request, because a failure IS the
+            // measurement: the whole point of #308 is to find where each path stops working, and in
+            // 'both' mode one path failing must not hide the other path's result.
+            if (mode === 'contents' || mode === 'both') {
+                var before = remainingUsage();
+                try {
+                    response.contents = readViaContents(gunzippedFile, observedFileType);
+                } catch (e) {
+                    response.contents = { failed: true, errorName: e.name, errorMessage: e.message };
+                }
+                response.contents.usageSpent = before - remainingUsage();
+            }
+
+            if (mode === 'stream' || mode === 'both') {
+                // In 'both' mode getContents() has already consumed the stream and the iterator would
+                // yield nothing - which reads as an empty file rather than a spent one, so it has to be
+                // handled rather than left to look like a result. resetStream() was tried first and did
+                // NOT rewind a gunzip temp file: mode 'both' reported linesYielded 0 against a file that
+                // streamed 500 lines under mode 'stream'. Decompressing a second time is cheap (gunzip
+                // costs no usage units, measured) and gives the stream read a genuinely untouched file.
+                var streamSource = (mode === 'both') ? compress.gunzip({ file: gzippedFile }) : gunzippedFile;
+                var streamBefore = remainingUsage();
+                try {
+                    response.stream = readViaStream(streamSource);
+                } catch (e) {
+                    response.stream = { failed: true, errorName: e.name, errorMessage: e.message };
+                }
+                response.stream.usageSpent = streamBefore - remainingUsage();
+            }
+
+            // Logged at audit level because observedFileType and the per-path usage cost are what #308
+            // and #336 both need, and a RESTlet response is not retained anywhere the next agent can read.
+            log.audit('Gzip verify', 'fileId: ' + fileId +
+                ', mode: ' + mode +
+                ', observedFileType: ' + observedFileType +
+                ', compressedBytes: ' + compressedBytes +
+                ', contents: ' + JSON.stringify(response.contents || null) +
+                ', stream: ' + JSON.stringify(response.stream || null));
+
+            // Phase 2's callers read recordCount, sha256 and decompressedChars off the top level and must
+            // keep working, so the active mode's numbers are promoted. 'both' promotes the streamed ones:
+            // if the two disagree the response still carries each separately, and streaming is the path
+            // the feed is meant to end up on.
+            var primary = (mode === 'contents') ? response.contents : response.stream;
+            if (primary && !primary.failed) {
+                response.recordCount = primary.recordCount;
+                response.sha256 = primary.sha256;
+                response.decompressedChars = primary.decompressedChars;
+            }
+
+            return response;
         };
 
         return { post };

--- a/src/Objects/Restlet/customscript_restlet_uploadfile.xml
+++ b/src/Objects/Restlet/customscript_restlet_uploadfile.xml
@@ -1,0 +1,22 @@
+<restlet scriptid="customscript_restlet_uploadfile">
+  <description></description>
+  <isinactive>F</isinactive>
+  <name>HC_RL_UploadFileToCabinet</name>
+  <notifyadmins>F</notifyadmins>
+  <notifyemails></notifyemails>
+  <notifyowner>T</notifyowner>
+  <notifyuser>F</notifyuser>
+  <scriptfile>[/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js]</scriptfile>
+  <scriptdeployments>
+    <scriptdeployment scriptid="customdeploy_restlet_uploadfile">
+      <allemployees>F</allemployees>
+      <allpartners>F</allpartners>
+      <allroles>T</allroles>
+      <audslctrole></audslctrole>
+      <isdeployed>T</isdeployed>
+      <loglevel>DEBUG</loglevel>
+      <status>RELEASED</status>
+      <title>HC_RL_UploadFileToCabinet</title>
+    </scriptdeployment>
+  </scriptdeployments>
+</restlet>

--- a/src/Objects/Restlet/customscript_restlet_verifygzip.xml
+++ b/src/Objects/Restlet/customscript_restlet_verifygzip.xml
@@ -1,0 +1,22 @@
+<restlet scriptid="customscript_restlet_verifygzip">
+  <description></description>
+  <isinactive>F</isinactive>
+  <name>HC_RL_VerifyGzipFile</name>
+  <notifyadmins>F</notifyadmins>
+  <notifyemails></notifyemails>
+  <notifyowner>T</notifyowner>
+  <notifyuser>F</notifyuser>
+  <scriptfile>[/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js]</scriptfile>
+  <scriptdeployments>
+    <scriptdeployment scriptid="customdeploy_restlet_verifygzip">
+      <allemployees>F</allemployees>
+      <allpartners>F</allpartners>
+      <allroles>T</allroles>
+      <audslctrole></audslctrole>
+      <isdeployed>T</isdeployed>
+      <loglevel>DEBUG</loglevel>
+      <status>RELEASED</status>
+      <title>HC_RL_VerifyGzipFile</title>
+    </scriptdeployment>
+  </scriptdeployments>
+</restlet>

--- a/src/deploy.xml
+++ b/src/deploy.xml
@@ -70,6 +70,7 @@
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_GetSuiteScriptCronExpression.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_StoreSFTPConfiguration.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js</path>
+        <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js</path>
 
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_SC_ImportTOFulfillmentReceipts_v2.js</path>
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedWhtoStoreTOJson_v2.js</path>
@@ -214,6 +215,7 @@
         <path>~/Objects/Restlet/customscript_restlet_getscript_cronexp.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_store_sftpconf.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_uploadfile.xml</path>
+        <path>~/Objects/Restlet/customscript_restlet_verifygzip.xml</path>
 
         <path>~/Objects/TransferOrderV2/customscript_hc_imp_to_fulfil_rcpt_v2.xml</path>
         <path>~/Objects/TransferOrderV2/customscript_hc_mr_exp_wh_store_to_v2.xml</path>

--- a/src/deploy.xml
+++ b/src/deploy.xml
@@ -69,6 +69,7 @@
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_RunSuiteScript.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_GetSuiteScriptCronExpression.js</path>
         <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_StoreSFTPConfiguration.js</path>
+        <path>~/FileCabinet/SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js</path>
 
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_SC_ImportTOFulfillmentReceipts_v2.js</path>
         <path>~/FileCabinet/SuiteScripts/TransferOrderV2/HC_MR_ExportedWhtoStoreTOJson_v2.js</path>
@@ -212,6 +213,7 @@
         <path>~/Objects/Restlet/customscript_restlet_runscript.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_getscript_cronexp.xml</path>
         <path>~/Objects/Restlet/customscript_restlet_store_sftpconf.xml</path>
+        <path>~/Objects/Restlet/customscript_restlet_uploadfile.xml</path>
 
         <path>~/Objects/TransferOrderV2/customscript_hc_imp_to_fulfil_rcpt_v2.xml</path>
         <path>~/Objects/TransferOrderV2/customscript_hc_mr_exp_wh_store_to_v2.xml</path>


### PR DESCRIPTION
NetSuite side of epic hotwax/mantle-netsuite-connector#310 — **Phases 1 and 2 in one PR.** Retargeted from the Phase 1 branch to `main` and consolidated; this supersedes #338, whose commits it already contains.

Moqui side: hotwax/mantle-netsuite-connector#327.

## Read this first

**Neither RESTlet has been run against a NetSuite account.** Everything below is verified *locally* — `node --check`, XML well-formedness, and the record-count logic against independent oracles. The live round trip has never happened, because the OAuth secrets are not on the machine this was written on.

Deliberately **no closing keywords**: #306, #307 and #308 all have success criteria requiring sandbox verification.

## What this adds

| file | purpose |
|---|---|
| `SuiteScripts/Restlet/HC_RL_UploadFileToCabinet.js` | Phase 1 — saves a base64 payload posted by Moqui into the File Cabinet, returns the file internal id |
| `SuiteScripts/Restlet/HC_RL_VerifyGzipFile.js` | Phase 2 — `post({fileId})` → gunzip, count NDJSON records, SHA-256, return |
| `Objects/Restlet/customscript_restlet_uploadfile.xml` | script + deployment object, `RELEASED`, `allroles` |
| `Objects/Restlet/customscript_restlet_verifygzip.xml` | same, structurally identical modulo names |
| `src/deploy.xml` | both registered in `<files>` and `<objects>` |

Neither does mapping or lookups — all feed logic stays in Moqui, and record creation stays with the generic creator (#336).

Phase 2 response:

```json
{ "status": "success", "fileId": "12345", "recordCount": 500, "sha256": "a91c...",
  "decompressedChars": 76406, "compressedBytes": 6206, "observedFileType": "MISCBINARY" }
```

## Four details worth reviewing closely

**1. Failures throw rather than return an error object.** The Moqui runner (`NetSuiteRestServiceRunner.getErrorMessage`) inspects a **2xx** body for `error`/`errorMessage` keys and downgrades them to a *warning*. So a soft error return would let a failed upload look successful to Moqui. `error.create` yields a non-2xx, which the runner escalates to a hard error.

**2. `BINARY_TYPES` decides base64 pass-through vs decode.** Binary types keep the base64 for `N/file` to decode; text types are decoded here via `N/encode`. Passing base64 to a text file type writes the base64 string itself as the file body. Note `file.Type` has **no `MISCBINARY`** as an input enum — it is an output value reused as input, which failed every gzipped upload with `UNSUPPORTED_FILE_TYPE` until `GZIP` was used instead (`3da8c3a`).

**3. The gunzipped file's inferred type.** `compress.gunzip()` returns a file whose `fileType` NetSuite infers. If that lands on a binary type, `getContents()` returns **base64, not text** — and hashing that string naively produces a mismatch that looks exactly like corruption. The digest is taken over the base64 with `inputEncoding: BASE_64`, so it covers the true decoded bytes and never passes through a character-encoding conversion. `observedFileType` is returned and `log.audit`ed, because *which* branch fires is the open question this PoC exists to answer — #308 and #336 both need it.

**4. Record counting differs between JavaScript and Java.** JS `split()` keeps trailing empty strings; Java's discards them. On an ordinary NDJSON file ending in a newline, a naive count gives **3 here and 2 on the Moqui side** — a phantom lost record on *every* feed file, with the bug living in the verifier. Both sides filter blanks explicitly. Keep that discipline in #336's creator.

## Verification

| check | result |
|---|---|
| `node --check` on both RESTlets | passes |
| `countRecords` against the 500-record sample | returns **500**, matching Groovy and `awk 'NF'`; a naive `split().length` returns 502 |
| SDF objects `xmllint`-clean | yes; verify object diffs identically against the upload object modulo names |
| live round trip | **never run** |

## Deployment traps

- Deployment status must be **Released**, not Testing — a Testing deployment is visible only to its owner and 404s for the integration role. This bit #338.
- `src/deploy.xml` is an **allowlist, not a glob**. Unregistered files deploy "successfully" and are silently omitted, surfacing later as a 404 that looks like a config error.
- `customsearch_hc_create_hotwax_fulfilled` blocks a full `project:deploy` (281 dependencies, 81 custom fields this repo does not own). Use `suitecloud file:upload` for individual files until that is fixed.

## Remaining, all environment-side

1. Deploy to the sandbox via SuiteCloud.
2. Read the deployed script ids and set `netsuite.restlet.filecabinet.upload` and `.verifygzip` on the Moqui side.
3. Upload a small text file; confirm it lands and the returned id loads.
4. Upload the same filename twice and record whether NetSuite replaces or duplicates.
5. Run the round trip and record `observedFileType`.

## Repo choice

#306 says the RESTlet belongs in `hotwax-gorjana-netsuite`. It is here instead, because this repo already holds the `Restlet/` convention and the four RESTlets that Moqui's `NS_SCRIPT_RESTLET` calls, and because #310 says the NetSuite side should be generic and not change per feed. Flagged explicitly so it can be moved if that is wrong.

## Issue links

Part of hotwax/mantle-netsuite-connector#306, #307, #308. Epic hotwax/mantle-netsuite-connector#310.
Supersedes #338.
